### PR TITLE
Fixed typo in Authentication slides

### DIFF
--- a/src/pages/authentication.njk
+++ b/src/pages/authentication.njk
@@ -156,7 +156,7 @@
 <section style="font-size: 90%;">
     <h3>The OAuths</h3>
     <ul>
-        <li>Allows a user to tell <em>authorization</em> server it's ok to allow a <em>client</em> (which can be a server) to access <em>resourc</em> server API on their behalf.</li>
+        <li>Allows a user to tell <em>authorization</em> server it's ok to allow a <em>client</em> (which can be a server) to access <em>resource</em> server API on their behalf.</li>
         <li>Example: User allows their email application to access gmail on their behalf.
             <ul>
                 <li>Client: super powered mail manager service $100/month guaranteed success (also a website/server, actually)</li>


### PR DESCRIPTION
"resourc" corrected to "resource"