### PR TITLE
Code Segment in Print

### DIFF
--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -1,206 +1,202 @@
 /* use Andika - Regular in .woff format */
 @font-face {
-  font-family: AndikaW;
-  src: url(/src/fonts/andika/web/Andika-Regular.woff2);
+    font-family: AndikaW;
+    src: url(/src/fonts/andika/web/Andika-Regular.woff2);
 }
 
 /* use Andika - Italic in .woff2 format */
 @font-face {
-  font-family: AndikaW;
-  font-style: italic;
-  src: url(/src/fonts/andika/web/Andika-Italic.woff2);
+    font-family: AndikaW;
+    font-style: italic;
+    src: url(/src/fonts/andika/web/Andika-Italic.woff2);
 }
 
 /* use Andika - Bold in .woff2 format */
 @font-face {
-  font-family: AndikaW;
-  font-weight: bold;
-  src: url(/src/fonts/andika/web/Andika-Bold.woff2);
+    font-family: AndikaW;
+    font-weight: bold;
+    src: url(/src/fonts/andika/web/Andika-Bold.woff2);
 }
 
 /* use Andika - Bold Italic in .woff2 format */
 @font-face {
-  font-family: AndikaW;
-  font-weight: bold;
-  font-style: italic;
-  src: url(/src/fonts/andika/web/Andika-BoldItalic.woff2);
+    font-family: AndikaW;
+    font-weight: bold;
+    font-style: italic;
+    src: url(/src/fonts/andika/web/Andika-BoldItalic.woff2);
 }
 
 @font-face {
-  font-family: AnonymousPro;
-  src: url(/src/fonts/anonymouspro/anonymous_pro.ttf);
+    font-family: AnonymousPro;
+    src: url(/src/fonts/anonymouspro/anonymous_pro.ttf);
 }
 
 @font-face {
-  font-family: AnonymousPro;
-  font-style: italic;
-  src: url(/src/fonts/anonymouspro/Anonymous_pro_i.ttf);
+    font-family: AnonymousPro;
+    font-style: italic;
+    src: url(/src/fonts/anonymouspro/Anonymous_pro_i.ttf);
 }
 
 @font-face {
-  font-family: AnonymousPro;
-  font-weight: bold;
-  src: url(/src/fonts/anonymouspro/anonymous_pro_b.ttf);
+    font-family: AnonymousPro;
+    font-weight: bold;
+    src: url(/src/fonts/anonymouspro/anonymous_pro_b.ttf);
 }
 
 @font-face {
-  font-family: AnonymousPro;
-  font-weight: bold;
-  font-style: italic;
-  src: url(/src/fonts/anonymouspro/anonymous_pro_bi.ttf);
+    font-family: AnonymousPro;
+    font-weight: bold;
+    font-style: italic;
+    src: url(/src/fonts/anonymouspro/anonymous_pro_bi.ttf);
 }
 
 .twoColumn {
-  columns: 2;
+    columns: 2;
 }
 
-.twoColumn > li {
-  margin-right: 1em;
-  margin-left: 1em;
+.twoColumn>li {
+    margin-right: 1em;
+    margin-left: 1em;
 }
 
 .little {
-  font-size: 70.7%;
+    font-size: 70.7%;
 }
 
 table.wikitable {
-  margin: 0 0;
-  text-align: center;
-  font-size: 40%;
+    margin: 0 0;
+    text-align: center;
+    font-size: 40%;
 }
 
 table.wikitable td,
 table.wikitable th {
-  text-align: center;
-  vertical-align: middle;
-  padding: 0.2em 0.2em 0.2em 0.2em;
+    text-align: center;
+    vertical-align: middle;
+    padding: 0.2em 0.2em 0.2em 0.2em;
 }
 
 .columns {
-  display: flex;
+    display: flex;
 }
 
 .column {
-  flex: 1;
+    flex: 1;
 }
 
 body {
-  --r-main-font: "AndikaW", "Arial", sans-serif;
-  --r-code-font: "AnonymousPro", "Consolas", monospace;
-  --r-heading-font: "AndikaW", "Arial", sans-serif;
-  --r-background-color: #ffe;
-  --r-block-margin: 0.5ch;
-  --r-heading3-font-size: 1.2em;
-  --r-heading4-font-size: 1.1em;
-  --r-heading-margin: 0 0 0.3333em 0;
-  letter-spacing: 0.033rem;
-  word-spacing: 110%;
-  font-feature-settings: "cv10" 1, "cv39" 1;
-  line-height: 1.3;
+    --r-main-font: 'AndikaW', 'Arial', sans-serif;
+    --r-code-font: 'AnonymousPro', 'Consolas', monospace;
+    --r-heading-font: 'AndikaW', 'Arial', sans-serif;
+    --r-background-color: #ffe;
+    --r-block-margin: 0.5ch;
+    --r-heading3-font-size: 1.2em;
+    --r-heading4-font-size: 1.1em;
+    --r-heading-margin: 0 0 0.3333em 0;
+    letter-spacing: 0.033rem;
+    word-spacing: 110%;
+    font-feature-settings: "cv10" 1, "cv39" 1;
+    line-height: 1.3;
 }
 
 cite {
-  font-size: 50%;
-  line-height: normal;
-  display: block;
+    font-size: 50%;
+    line-height: normal;
+    display: block;
 }
 
 section a {
-  overflow-wrap: break-word;
-  word-break: break-all;
+    overflow-wrap: break-word;
+    word-break: break-all;
 }
 
-h3 > b {
-  font-size: 133%;
+h3>b {
+    font-size: 133%;
 }
 
-code > pre {
-  background-color: red !important;
-  color: yellow;
+code>pre {
+    background-color: red !important;
+    color: yellow;
 }
 
 body code {
-  letter-spacing: 0;
-  font-size: 85%;
+    letter-spacing: 0;
+    font-size: 85%;
 }
 
 body .reveal pre {
-  letter-spacing: 0;
-  word-spacing: normal;
-  margin: 1ex auto;
-  width: 100%;
-  font-size: calc(var(--r-main-font-size) * 0.61);
-  line-height: normal;
+    letter-spacing: 0;
+    word-spacing: normal;
+    margin: 1ex auto;
+    width: 100%;
+    font-size: calc(var(--r-main-font-size) * 0.61);
+    line-height: normal;
 }
 
-section > li {
-  background-color: red;
+section>li {
+    background-color: red;
 }
 
 dl,
-body .reveal section > dl,
+body .reveal section>dl,
 ol,
-body .reveal section > ol,
+body .reveal section>ol,
 ul,
-body .reveal section > ul {
-  margin: 0;
-  display: block;
+body .reveal section>ul {
+    margin: 0;
+    display: block;
 }
 
 dl,
-body .reveal section > dl {
-  display: flow-root;
+body .reveal section>dl {
+    display: flow-root;
 }
 
-dl > dt,
-body .reveal dl > dt {
-  float: inline-start;
-  clear: inline-start;
-  display: block;
-  min-width: 0;
-  max-width: 50%;
+dl>dt,
+body .reveal dl>dt {
+    float: inline-start;
+    clear: inline-start;
+    display: block;
+    min-width: 0;
+    max-width: 50%;
 }
 
-dl > dd,
-body .reveal dl > dd {
-  display: block;
-  clear: none;
-  float: none;
-  margin: 0;
-  padding: 0;
+dl>dd,
+body .reveal dl>dd {
+    display: block;
+    clear: none;
+    float: none;
+    margin: 0;
+    padding: 0;
 }
 
 dt::after {
-  content: "—";
+    content: "—";
 }
 
-dd > ul,
-body .reveal dd > ul {
-  display: block;
-  clear: left;
-  float: none;
-  font-size: 90%;
+dd>ul,
+body .reveal dd>ul {
+    display: block;
+    clear: left;
+    float: none;
+    font-size: 90%;
 }
 
-input[type="date"],
-input[type="submit"],
-select,
-input[type="file"] {
-  font-size: 75%;
+input[type='date'], input[type='submit'], select, input[type='file'] {
+    font-size: 75%;
 }
 
-input[type="checkbox"],
-input[type="radio"] {
-  width: 1.5lh;
-  height: 1.5lh;
+input[type='checkbox'], input[type='radio'] {
+    width: 1.5lh;
+    height: 1.5lh;
 }
 
-input[type="range"] {
-  height: 1.5lh;
+input[type='range'] {
+    height: 1.5lh;
 }
 
 form {
-  border: 0.5ex dashed black;
+    border: 0.5ex dashed black;
 }
 
 /* Properly formats code segment when you print the slides. Currently when you print the slides or download slides

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -1,200 +1,215 @@
 /* use Andika - Regular in .woff format */
 @font-face {
-    font-family: AndikaW;
-    src: url(/src/fonts/andika/web/Andika-Regular.woff2);
+  font-family: AndikaW;
+  src: url(/src/fonts/andika/web/Andika-Regular.woff2);
 }
 
 /* use Andika - Italic in .woff2 format */
 @font-face {
-    font-family: AndikaW;
-    font-style: italic;
-    src: url(/src/fonts/andika/web/Andika-Italic.woff2);
+  font-family: AndikaW;
+  font-style: italic;
+  src: url(/src/fonts/andika/web/Andika-Italic.woff2);
 }
 
 /* use Andika - Bold in .woff2 format */
 @font-face {
-    font-family: AndikaW;
-    font-weight: bold;
-    src: url(/src/fonts/andika/web/Andika-Bold.woff2);
+  font-family: AndikaW;
+  font-weight: bold;
+  src: url(/src/fonts/andika/web/Andika-Bold.woff2);
 }
 
 /* use Andika - Bold Italic in .woff2 format */
 @font-face {
-    font-family: AndikaW;
-    font-weight: bold;
-    font-style: italic;
-    src: url(/src/fonts/andika/web/Andika-BoldItalic.woff2);
+  font-family: AndikaW;
+  font-weight: bold;
+  font-style: italic;
+  src: url(/src/fonts/andika/web/Andika-BoldItalic.woff2);
 }
 
 @font-face {
-    font-family: AnonymousPro;
-    src: url(/src/fonts/anonymouspro/anonymous_pro.ttf);
+  font-family: AnonymousPro;
+  src: url(/src/fonts/anonymouspro/anonymous_pro.ttf);
 }
 
 @font-face {
-    font-family: AnonymousPro;
-    font-style: italic;
-    src: url(/src/fonts/anonymouspro/Anonymous_pro_i.ttf);
+  font-family: AnonymousPro;
+  font-style: italic;
+  src: url(/src/fonts/anonymouspro/Anonymous_pro_i.ttf);
 }
 
 @font-face {
-    font-family: AnonymousPro;
-    font-weight: bold;
-    src: url(/src/fonts/anonymouspro/anonymous_pro_b.ttf);
+  font-family: AnonymousPro;
+  font-weight: bold;
+  src: url(/src/fonts/anonymouspro/anonymous_pro_b.ttf);
 }
 
 @font-face {
-    font-family: AnonymousPro;
-    font-weight: bold;
-    font-style: italic;
-    src: url(/src/fonts/anonymouspro/anonymous_pro_bi.ttf);
+  font-family: AnonymousPro;
+  font-weight: bold;
+  font-style: italic;
+  src: url(/src/fonts/anonymouspro/anonymous_pro_bi.ttf);
 }
 
 .twoColumn {
-    columns: 2;
+  columns: 2;
 }
 
-.twoColumn>li {
-    margin-right: 1em;
-    margin-left: 1em;
+.twoColumn > li {
+  margin-right: 1em;
+  margin-left: 1em;
 }
 
 .little {
-    font-size: 70.7%;
+  font-size: 70.7%;
 }
 
 table.wikitable {
-    margin: 0 0;
-    text-align: center;
-    font-size: 40%;
+  margin: 0 0;
+  text-align: center;
+  font-size: 40%;
 }
 
 table.wikitable td,
 table.wikitable th {
-    text-align: center;
-    vertical-align: middle;
-    padding: 0.2em 0.2em 0.2em 0.2em;
+  text-align: center;
+  vertical-align: middle;
+  padding: 0.2em 0.2em 0.2em 0.2em;
 }
 
 .columns {
-    display: flex;
+  display: flex;
 }
 
 .column {
-    flex: 1;
+  flex: 1;
 }
 
 body {
-    --r-main-font: 'AndikaW', 'Arial', sans-serif;
-    --r-code-font: 'AnonymousPro', 'Consolas', monospace;
-    --r-heading-font: 'AndikaW', 'Arial', sans-serif;
-    --r-background-color: #ffe;
-    --r-block-margin: 0.5ch;
-    --r-heading3-font-size: 1.2em;
-    --r-heading4-font-size: 1.1em;
-    --r-heading-margin: 0 0 0.3333em 0;
-    letter-spacing: 0.033rem;
-    word-spacing: 110%;
-    font-feature-settings: "cv10" 1, "cv39" 1;
-    line-height: 1.3;
+  --r-main-font: "AndikaW", "Arial", sans-serif;
+  --r-code-font: "AnonymousPro", "Consolas", monospace;
+  --r-heading-font: "AndikaW", "Arial", sans-serif;
+  --r-background-color: #ffe;
+  --r-block-margin: 0.5ch;
+  --r-heading3-font-size: 1.2em;
+  --r-heading4-font-size: 1.1em;
+  --r-heading-margin: 0 0 0.3333em 0;
+  letter-spacing: 0.033rem;
+  word-spacing: 110%;
+  font-feature-settings: "cv10" 1, "cv39" 1;
+  line-height: 1.3;
 }
 
 cite {
-    font-size: 50%;
-    line-height: normal;
-    display: block;
+  font-size: 50%;
+  line-height: normal;
+  display: block;
 }
 
 section a {
-    overflow-wrap: break-word;
-    word-break: break-all;
+  overflow-wrap: break-word;
+  word-break: break-all;
 }
 
-h3>b {
-    font-size: 133%;
+h3 > b {
+  font-size: 133%;
 }
 
-code>pre {
-    background-color: red !important;
-    color: yellow;
+code > pre {
+  background-color: red !important;
+  color: yellow;
 }
 
 body code {
-    letter-spacing: 0;
-    font-size: 85%;
+  letter-spacing: 0;
+  font-size: 85%;
 }
 
 body .reveal pre {
-    letter-spacing: 0;
-    word-spacing: normal;
-    margin: 1ex auto;
-    width: 100%;
-    font-size: calc(var(--r-main-font-size) * 0.61);
-    line-height: normal;
+  letter-spacing: 0;
+  word-spacing: normal;
+  margin: 1ex auto;
+  width: 100%;
+  font-size: calc(var(--r-main-font-size) * 0.61);
+  line-height: normal;
 }
 
-section>li {
-    background-color: red;
+section > li {
+  background-color: red;
 }
 
 dl,
-body .reveal section>dl,
+body .reveal section > dl,
 ol,
-body .reveal section>ol,
+body .reveal section > ol,
 ul,
-body .reveal section>ul {
-    margin: 0;
-    display: block;
+body .reveal section > ul {
+  margin: 0;
+  display: block;
 }
 
 dl,
-body .reveal section>dl {
-    display: flow-root;
+body .reveal section > dl {
+  display: flow-root;
 }
 
-dl>dt,
-body .reveal dl>dt {
-    float: inline-start;
-    clear: inline-start;
-    display: block;
-    min-width: 0;
-    max-width: 50%;
+dl > dt,
+body .reveal dl > dt {
+  float: inline-start;
+  clear: inline-start;
+  display: block;
+  min-width: 0;
+  max-width: 50%;
 }
 
-dl>dd,
-body .reveal dl>dd {
-    display: block;
-    clear: none;
-    float: none;
-    margin: 0;
-    padding: 0;
+dl > dd,
+body .reveal dl > dd {
+  display: block;
+  clear: none;
+  float: none;
+  margin: 0;
+  padding: 0;
 }
 
 dt::after {
-    content: "—";
+  content: "—";
 }
 
-dd>ul,
-body .reveal dd>ul {
-    display: block;
-    clear: left;
-    float: none;
-    font-size: 90%;
+dd > ul,
+body .reveal dd > ul {
+  display: block;
+  clear: left;
+  float: none;
+  font-size: 90%;
 }
 
-input[type='date'], input[type='submit'], select, input[type='file'] {
-    font-size: 75%;
+input[type="date"],
+input[type="submit"],
+select,
+input[type="file"] {
+  font-size: 75%;
 }
 
-input[type='checkbox'], input[type='radio'] {
-    width: 1.5lh;
-    height: 1.5lh;
+input[type="checkbox"],
+input[type="radio"] {
+  width: 1.5lh;
+  height: 1.5lh;
 }
 
-input[type='range'] {
-    height: 1.5lh;
+input[type="range"] {
+  height: 1.5lh;
 }
 
 form {
-    border: 0.5ex dashed black;
+  border: 0.5ex dashed black;
+}
+
+/* Properly formats code segment when you print the slides. Currently when you print the slides or download slides
+in Ipad for annotation or on computer for notes, the code segment is big and because its big , it adds a scrollabar bar
+at the end. But when you print the notes , you cannot access the scrollbar making the code cut off. 
+Using this css , it will format the code better and make sure it will remain within the Container box and 
+when the notes are printed , it will adjust accordinly to the container and make sure the whole code segment is seen*/
+@media print {
+  body code {
+    font-size: calc(0.3vw + 1vh);
+  }
 }


### PR DESCRIPTION
Properly formats code segment when you print the slides. Currently, when you print the slides or download slides in Ipad for annotation or on computer for notes, the code segment is big and because its big , it adds a scrollabar bar at the end. But when you print the notes , you cannot access the scroll bar making the code cut off. Using this css , it will format the code better and make sure it will remain within the Container box and when the notes are printed , it will adjust accordingly to the container and make sure the whole code segment is seen. an example is below

![image](https://github.com/uofa-cmput404/slides-xt/assets/93953652/fa0f0bd3-6d59-4eb4-9484-decb512bb9f6)

the above is changed to 

![image](https://github.com/uofa-cmput404/slides-xt/assets/93953652/e91607f5-f8a3-4de3-824c-cbd4a17a9693)


I also cleaned up the CSS file to make sure the indentation is properly, I made sure to pass the file through a linter and made sure the spacing and formatting is correct.

name - Pratham Arora
ccid- pratham2