### PR TITLE
Print mode

### DIFF
--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -198,3 +198,15 @@ input[type='range'] {
 form {
     border: 0.5ex dashed black;
 }
+
+/* Properly formats code segment when you print the slides. Currently when you print the slides or download slides
+in Ipad for annotation or on computer for notes, the code segment is big and because its big , it adds a scrollabar bar
+at the end. But when you print the notes , you cannot access the scrollbar making the code cut off. 
+Using this css , it will format the code better and make sure it will remain within the Container box and 
+when the notes are printed , it will adjust accordinly to the container and make sure the whole code segment is seen*/
+@media print {
+    body code {
+      font-size: calc(0.3vw + 1vh);
+    }
+  }
+  


### PR DESCRIPTION
Properly formats code segment when you print the slides. Currently, when you print the slides or download slides in Ipad for annotation or on computer for notes, the code segment is big and because its big , it adds a scrollabar bar at the end. But when you print the notes , you cannot access the scroll bar making the code cut off. Using this css , it will format the code better and make sure it will remain within the Container box and when the notes are printed , it will adjust accordingly to the container and make sure the whole code segment is seen. an example is below

![image](https://github.com/uofa-cmput404/slides-xt/assets/93953652/c193f5ab-f78d-4fe3-8aed-87eef46c0879)

the above is changed to

![image](https://github.com/uofa-cmput404/slides-xt/assets/93953652/518a23a7-e9b4-4072-8a6a-6a57e74e5b6b)


name - Pratham Arora
ccid- pratham2