### PR TITLE
Remove Duplicate Bullet Point

### DIFF
--- a/src/pages/http.njk
+++ b/src/pages/http.njk
@@ -656,7 +656,6 @@ Content-Encoding: gzip\r\n
                         </ul>
                     </li>
                     <li>We can send query parameters along an HTTP get in the URL</li>
-                    <li>It is considered bad if GET request causes the server to change data&mdash;we should use a different HTTP method for that</li>
                 </ul>
             </section>
             <section>


### PR DESCRIPTION
The bullet point in the previous slide on the GET method:

```
- It is considered bad if GET request causes the server to change data—we should use a different HTTP method for that
```

Seem to be redundantly copied to the following slide on the POST method. 