### PR TITLE
PWA Resource link fix

### DIFF
--- a/src/pages/pwa.njk
+++ b/src/pages/pwa.njk
@@ -329,11 +329,11 @@
 <section>
     <h3>Resources and References</h3>
     <ul>
-        <li><a href="https://business.adobe.com/blog/basics/progressive-web-app-examples"></a>Adobe Blog Progressive web apps</li>
-        <li><a href="https://medium.com/one-more-thing-studio/native-react-native-or-pwa-what-should-i-choose-e63f18732b5e"></a>Native, React-native or PWA</li>
-        <li><a href="https://youtu.be/1WWweyBaWZk?si=Wfdd0nMgZ9L6NRso"></a>What Is A Progressive Web App Youtube</li>
-        <li><a href="https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps"></a>mdn Progressive web apps</li>
-        <li><a href="https://developer.chrome.com/docs/workbox/service-worker-overview"></a>Service worker overview</li>
+        <li><a href="https://business.adobe.com/blog/basics/progressive-web-app-examples">Adobe Blog Progressive web apps</a></li>
+        <li><a href="https://medium.com/one-more-thing-studio/native-react-native-or-pwa-what-should-i-choose-e63f18732b5e">Native, React-native or PWA</a></li>
+        <li><a href="https://youtu.be/1WWweyBaWZk?si=Wfdd0nMgZ9L6NRso">What Is A Progressive Web App Youtube</a></li>
+        <li><a href="https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps">mdn Progressive web apps</a></li>
+        <li><a href="https://developer.chrome.com/docs/workbox/service-worker-overview">Service worker overview</a></li>
 
     </ul>
 </section>
@@ -342,3 +342,4 @@
 
 
 {% endblock %}
+


### PR DESCRIPTION
Link mask text was outside of <a> tag, moved it inside and links should now be clickable