### PR TITLE
Fix broken image reference in more-http.njk

### DIFF
--- a/src/pages/more-http.njk
+++ b/src/pages/more-http.njk
@@ -695,7 +695,7 @@ content-length: 60
         </ul>
     </section>
     <section>
-        Fancy 404 pages...<br> <img class="stretch noborder" src="images/github_404.png">
+        Fancy 404 pages...<br> <img class="stretch noborder" src="/src/images/github_404.png">
     </section>
     <section>
         <ul style="font-size: 85%">


### PR DESCRIPTION
The image `github_404.png` was not displaying due to an incorrect relative path. Changed the src attribute from `mages/github_404.png` to `/src/images/github_404.png` to properly reference the image in the Vite project structure.

<img width="861" height="527" alt="Screenshot 2025-12-04 at 6 01 14 PM" src="https://github.com/user-attachments/assets/eefbd03c-4cdb-49a0-9f78-6c1a0b9995d7" />

<img width="986" height="693" alt="Screenshot 2025-12-04 at 6 00 54 PM" src="https://github.com/user-attachments/assets/1efb9d21-408f-43cf-bf7a-756437decfa4" />