### PR TITLE
fix copy code button on js slides

### DIFF
--- a/src/pages/js.njk
+++ b/src/pages/js.njk
@@ -1113,5 +1113,5 @@ logger = new ActionLogger([consoleLogger, arrayLogger.makeLogger()]);
         <li><a href="http://www.w3.org/TR/WD-DOM/introduction.html">W3C What is a DOM</a></li>
     </ul>
 </section>
-<script src="/src/scripts/copyCodeButton.js"></script>
+<script type="module" src="/src/scripts/copyCodeButton.js"></script>
 {% endblock %}


### PR DESCRIPTION
The copy code button was not showing up on the JavaScript slides because copyCodeButton.js was loaded as a plain script instead of a module.