### PR TITLE
Add a scrollable view changer and slide-counter

### DIFF
--- a/main.js
+++ b/main.js
@@ -138,6 +138,7 @@ Reveal.initialize({
     hash: true,
     respondToHashChanges: true,
     history: false,
+    slideNumber: 'c/t',
     plugins: [
         RevealMarkdown
     ]

--- a/src/layouts/main.njk
+++ b/src/layouts/main.njk
@@ -9,6 +9,8 @@
         <script type="module" src="../../main.js"></script>
     </head>
     <body>
+       <a href="?print-pdf" id="print-button">Scrollable View</a>
+
         <div class="reveal">
             <div class="slides">
             {% block slides %}
@@ -18,5 +20,19 @@
             {% include "components/copyright_info.njk" %}
             </div>
           </div>
+
+        <script>
+            const button = document.getElementById('print-button');
+            const isPrintMode = window.location.search.includes('print-pdf');
+
+            if (isPrintMode) {
+                button.textContent = 'Slide View';
+                button.href = window.location.pathname;
+            } else {
+                buttontn.textContent = 'Scrollable View';
+                button.href = '?print-pdf';
+            }
+        </script>
+
     </body>    
 </html>

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -571,22 +571,40 @@ body span.v2 {
 
 #print-button {
     position: fixed;
-    top: 10px;
-    right: 10px;
+    top: 16px;
+    right: 16px;
     z-index: 9999;
-    background: #fff;
-    border: 1px solid #ccc;
-    padding: 6px 12px;
-    border-radius: 4px;
-    font-size: 14px;
+    background: linear-gradient(135deg, #2a75de, #2a75de);
+    color: #fff;
+    border: none;
+    padding: 10px 16px;
+    border-radius: 999px;
+    font-size: 12px;
+    letter-spacing: 0.03em;
     text-decoration: none;
-    color: #333;
+    cursor: pointer;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    transition: all 0.2s ease;
 }
-
-#print-buttonn:hover {
-    background: #f0f0f0;
+#print-button:hover {
+    transform: translateY(-2px) scale(1.03);
+    box-shadow: 0 8px 18px rgba(0, 0, 0, 0.2);
 }
-
+/* Animate clicking */
+#print-button:active {
+    transform: translateY(0) scale(0.98);
+    box-shadow: 0 3px 8px rgba(0, 0, 0, 0.15);
+}
+/* Hide the button during printing */
 @media print {
     #print-button { display: none; }
+}
+
+.reveal .slide-number {
+  pointer-events: none;
+  background: transparent !important; /* remove the dark box */
+  color: black !important; 
+  /* move to the bottom left side of the page: */
+  right: auto !important; 
+  top: auto !important;     
 }

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -568,3 +568,25 @@ body span.v1 {
 body span.v2 {
     color: #04f;
 }
+
+#print-button {
+    position: fixed;
+    top: 10px;
+    right: 10px;
+    z-index: 9999;
+    background: #fff;
+    border: 1px solid #ccc;
+    padding: 6px 12px;
+    border-radius: 4px;
+    font-size: 14px;
+    text-decoration: none;
+    color: #333;
+}
+
+#print-buttonn:hover {
+    background: #f0f0f0;
+}
+
+@media print {
+    #print-button { display: none; }
+}


### PR DESCRIPTION
Sometimes, the slides seem tedious to go through because I can only see one slide at a time. To improve the reading experience, I added a button that allows you to toggle between the original view, and a scrollable view (where all the slides are shown in one continuous screen). The scrollable view adds `?print-pdf` to the url, which utilizes reveal.js's printing stylesheet.

Also added a slide counter (current/total) so that you know how far along into the slides you are.