### PR TITLE
Fix typos and improve wording in PWA slides

### DIFF
--- a/src/pages/pwa.njk
+++ b/src/pages/pwa.njk
@@ -46,7 +46,7 @@
 <section>
     <h3>Installer script</h3>
     <ul>
-        <li>Loaded by HTML (directly or indirectly) &lt;script> tag</li>
+        <li>Loaded by an HTML &lt;script> tag, either directly or indirectly</li>
         <li>Should be in all the main pages of the app</li>
         <li>Uses the <code>navigator.serviceWorker</code> object, a <code>ServiceWorkerContainer</code></li>
         <li>Has access to the page and everything like a normal script</li>
@@ -114,7 +114,7 @@
                 <li>console.log messages will not show up in the tab!</li>
             </ul>
         </li>
-        <li>Runs in a seperate thread</li>
+        <li>Runs in a separate thread</li>
     </ul>
 </section>
 <section>


### PR DESCRIPTION
This PR fixes a few small issues in the PWA slides to improve clarity and correctness:

1. "seperate" to "separate"
2. Improved wording for the script tag description for better readability

These changes are minimal and do not affect the meaning of the slides, but make them clearer